### PR TITLE
Fix mobile screenshot size

### DIFF
--- a/src/scss/BrowseApps.scss
+++ b/src/scss/BrowseApps.scss
@@ -194,6 +194,7 @@
     &__screenshot {
       flex: 0 0 auto;
       max-height: 600px;
+      max-width: 100%;
       margin: 0 30px;
     }
   }


### PR DESCRIPTION
This PR adds a `max-width` to the screenshot in `/apps` since it overflows on mobile:

Currently:

![joinmastodon.org/apps on mobile where the screenshot of an iphone is overflowing](https://user-images.githubusercontent.com/18014039/163683759-47c8f29e-b3cc-4397-a358-4a3910f0bb97.png)

With `max-width: 100%`:

![joinmastodon.org/apps on mobile where the screenshot of an iphone is not overflowing](https://user-images.githubusercontent.com/18014039/163683810-3b0e7670-f918-4dd0-bb7b-38a900d6cf29.png)
