### PR TITLE
Invalidate translations after string change

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -2,4 +2,3 @@ commit_message: '[ci skip]'
 files:
   - source: /src/locales/en.json
     translation: /src/locales/%two_letters_code%.json
-    update_option: update_as_unapproved


### PR DESCRIPTION
Change the behavior for string edits so that Crowdin translators are notified about them. Same was implemented in December for Mastodon strings here: https://github.com/mastodon/mastodon/pull/17085