### PR TITLE
Mark sponsored links for crawlers

### DIFF
--- a/src/BrowseApps.js
+++ b/src/BrowseApps.js
@@ -294,7 +294,7 @@ const BrowseApps = ({ intl }) => (
 
         <div className='logo-grid'>
           <div>
-            {sponsors.map(x => <a key={x.href} href={x.href}><img src={x.src} alt={x.alt} /></a>)}
+            {sponsors.map(x => <a key={x.href} href={x.href} rel='sponsored'><img src={x.src} alt={x.alt}  /></a>)}
           </div>
         </div>
       </div>

--- a/src/Sponsorship.js
+++ b/src/Sponsorship.js
@@ -109,7 +109,7 @@ const Sponsorship = ({ intl }) => (
       <div className='container'>
         <div className='tier'>
           <div className='sponsors-list--logos'>
-            {[...platinumSponsors.filter(sponsor => sponsor.href !== 'https://www.cibdol.com/'), ...goldSponsors].map(sponsor => <a key={sponsor.href} href={sponsor.href}><img src={sponsor.src} alt={sponsor.alt} /></a>)}
+            {[...platinumSponsors.filter(sponsor => sponsor.href !== 'https://www.cibdol.com/'), ...goldSponsors].map(sponsor => <a key={sponsor.href} href={sponsor.href} rel="sponsored"><img src={sponsor.src} alt={sponsor.alt} /></a>)}
           </div>
         </div>
       </div>

--- a/src/Sponsorship.js
+++ b/src/Sponsorship.js
@@ -148,7 +148,7 @@ const Sponsorship = ({ intl }) => (
 
         <div className='sponsors-list--badges'>
           <ul>
-            {silverSponsors.map(sponsor => <li key={sponsor.name}><a href={sponsor.href || 'https://joinmastodon.org/sponsors'} rel={sponsor.nofollow ? 'nofollow' : null}><img src={sponsor.src || noAvatar} alt='' /> <span><strong>{sponsor.name}</strong><span>{sponsor.href || '-'}</span></span></a></li>)}
+            {silverSponsors.map(sponsor => <li key={sponsor.name}><a href={sponsor.href || 'https://joinmastodon.org/sponsors'} rel={sponsor.nofollow ? 'sponsored nofollow' : 'sponsored'}><img src={sponsor.src || noAvatar} alt='' /> <span><strong>{sponsor.name}</strong><span>{sponsor.href || '-'}</span></span></a></li>)}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Google's Search Central [recommends](https://developers.google.com/search/docs/advanced/guidelines/qualify-outbound-links) that sponsored links are marked with `rel="sponsored"`.
This adds that tag to the different sponsor links