### PR TITLE
Update BrowseApps.js

### DIFF
--- a/src/BrowseApps.js
+++ b/src/BrowseApps.js
@@ -162,7 +162,6 @@ const apps = {
       name: 'Mastonaut (Mac)',
       icon: mastonaut,
       url: 'https://itunes.apple.com/us/app/mastonaut/id1450757574',
-      paid: true
     },
 
     {


### PR DESCRIPTION
Mastonaut is free to install from the app store and there doesn't appear to be any in-app purchases.