### PR TITLE
Add gd locale

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -21,6 +21,7 @@ const supportedLanguages = [
   { locale: 'eu', language: 'Euskara' },
   //{ locale: 'fi', language: 'Suomi' },
   { locale: 'fr', language: 'Français' },
+  { locale: 'gd', language: 'Gàidhlig' },
   //{ locale: 'he', language: 'עברית' },
   { locale: 'it', language: 'Italiano' },
   { locale: 'ja', language: '日本語' },

--- a/translationRunner.js
+++ b/translationRunner.js
@@ -14,6 +14,7 @@ manageTranslations({
     'eu',
     'fi',
     'fr',
+    'gd',
     'he',
     'it',
     'ja',


### PR DESCRIPTION
`es-AR` is also missing, but I don't know whether to call it "Español de Argentina" or "Español argentino", so I left it alone.