### PR TITLE
Updated copy in navigation

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -34,19 +34,19 @@ const Header = () => {
         {
           value: "https://blog.joinmastodon.org/",
           label: <FormattedMessage id="nav.blog.title" defaultMessage="Blog" />,
-          description: <FormattedMessage id="nav.blog.description" defaultMessage="Description for the blog" />,
+          description: <FormattedMessage id="nav.blog.description" defaultMessage="Mastodon news and updates" />,
         }, {
           value: "https://github.com/mastodon/mastodon/discussions",
           label: <FormattedMessage id="nav.support.title" defaultMessage="Support" />,
-          description: <FormattedMessage id="nav.support.description" defaultMessage="Description for support" />,
+          description: <FormattedMessage id="nav.support.description" defaultMessage="Q&A and community discussions on GitHub" />,
         }, {
           value: "https://github.com/mastodon/mastodon",
           label: <FormattedMessage id="nav.code.title" defaultMessage="Code" />,
-          description: <FormattedMessage id="nav.code.description" defaultMessage="Code on GitHub. Description for code" />,
+          description: <FormattedMessage id="nav.code.description" defaultMessage="Source code for Mastodon on GitHub" />,
         }, {
           value: "https://docs.joinmastodon.org",
           label: <FormattedMessage id="nav.docs.title" defaultMessage="Documentation" />,
-          description: <FormattedMessage id="nav.docs.description" defaultMessage="Description for documentation" />,
+          description: <FormattedMessage id="nav.docs.description" defaultMessage="API reference, feature walkthroughs, and technical overview" />,
         }
       ],
     }, {


### PR DESCRIPTION
Replaced the placeholder copy in the navigation's default messages. Now:

<img width="370" alt="image" src="https://user-images.githubusercontent.com/1642599/187254065-1eeebeeb-84d0-4fb9-8de0-8ee09390aefb.png">
