### PR TITLE
Mastodon isn't a network, it's part of a network

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -37,7 +37,7 @@
   "home.sponsors.body": "Mastodon is free and open-source software developed by a non-profit organization. Public support directly affects development and evolution.",
   "home.sponsors.title": "Independent and self made",
   "home.testimonials.title": "What our users are saying",
-  "home.why.decentralized.copy": "Not controlled by a single website or company, Mastodon is a network of completely independent service providers forming a global, cohesive social media platform.",
+  "home.why.decentralized.copy": "Not controlled by a single website or company, Mastodon is part of a network of completely independent service providers forming a global, cohesive social media platform.",
   "home.why.decentralized.title": "Decentralized",
   "home.why.not_for_sale.copy": "No surprises. Your feed is curated and created by you. We will never serve ads or push profiles for you to see. That means your data is yours and yours alone",
   "home.why.not_for_sale.title": "Not for Sale",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -270,7 +270,7 @@ const WhyMastodon = () => {
               <FormattedMessage
                 id="home.why.decentralized.copy"
                 defaultMessage="Not controlled by a 
-            single website or company, Mastodon is a network of completely independent service providers forming 
+            single website or company, Mastodon is part of a network of completely independent service providers forming 
             a global, cohesive social media platform. "
               />
             }


### PR DESCRIPTION
I've changed it from 
> Mastodon is a network of completely independent service providers forming a global […]

to
> Mastodon is **part of** a network of completely independent service providers forming a global […]

This should really be done because it could confuse people otherwise