### PR TITLE
Use left aligned hero on `/about`

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -19,7 +19,7 @@ import press from "../data/press"
 const About = () => (
   <Layout>
     <div dir="ltr" className="[unicode-bidi:plaintext]">
-      <Hero homepage desktopImage={heroImage} mobileImage={heroImage}>
+      <Hero desktopImage={heroImage} mobileImage={heroImage}>
         <h1 className="h1 pt-16 mb-8">We develop Mastodon</h1>
         <p className="sh1">
           Free, open-source decentralized social media


### PR DESCRIPTION
This left aligns the text on `/about` to match the text placement on all other inner pages.
<img width="1792" alt="Screen Shot 2022-10-28 at 3 45 00 PM" src="https://user-images.githubusercontent.com/31963784/198720182-3222f128-2782-47a7-914e-926c860974d4.png">
