### PR TITLE
Fix text size

### DIFF
--- a/pages/servers.tsx
+++ b/pages/servers.tsx
@@ -160,7 +160,7 @@ const Servers = () => {
             />
 
 
-            <p className="my-8 md:mt-0  text-gray-2">
+            <p className="my-8 md:mt-0 b3 text-gray-2">
               <FormattedMessage
                 id="covenant.learn_more"
                 defaultMessage="All servers listed here must commit to the <link>Mastodon Server Covenant</link>."


### PR DESCRIPTION
Reduces the text size to `b3`, match the text beneath the network health section.
<img width="390" alt="Screen Shot 2022-11-01 at 12 30 36 PM" src="https://user-images.githubusercontent.com/31963784/199286000-2f67f040-d323-497f-aba1-82fcb45eb532.png">
