### PR TITLE
Fixes sponsor card truncation overflow

### DIFF
--- a/components/SponsorCard.tsx
+++ b/components/SponsorCard.tsx
@@ -7,7 +7,7 @@ const SponsorCard = ({ sponsor, tier }) => {
   return (
     <div
       className={classNames(
-        "grid grid-cols-[auto_1fr] gap-4 rounded p-4",
+        "grid grid-cols-[auto] gap-4 rounded p-4",
         tier === "generalHighlighted" && "bg-nightshade-900 text-white",
         tier === "silver" && "border border-gray-3 hover:bg-gray-4"
       )}
@@ -19,7 +19,7 @@ const SponsorCard = ({ sponsor, tier }) => {
           <div className="h-[56px] w-[56px] rounded-md bg-blurple-gradient" />
         ))}
 
-      <div className="flex flex-col justify-center">
+      <div className="w-full truncate">
         <span className={classNames("b3 !leading-[1.5]", tier === "generalHighlighted" ? "text-nightshade-100" : "text-gray-1")}>
           {tier === "silver" ? (
             <FormattedMessage


### PR DESCRIPTION
Currently when sponsor names on https://joinmastodon.org/sponsors are longer than the box they are in can fit they overflow outside of the box despite being set to truncate (`text-overflow: ellipsis`)

<img width="1171" alt="Before truncation fix" src="https://user-images.githubusercontent.com/5672810/200227501-2ad184a9-ae7e-4cd0-a11a-d7cc9deacc71.png">

This PR changes some classes around so that doesn't happen anymore!  The grid column template for the card also doesn't have an extra 1fr column now which ensures the maximum amount of space in the card is taken up by the sponsor name before truncating.  Previously with `auto_1fr`there was a 1fr space after the auto space where the actual content lives.

<img width="1075" alt="After truncation fix" src="https://user-images.githubusercontent.com/5672810/200227672-5ad5cd51-9104-4581-900a-c48ac2fcc4d9.png">

Tested on Firefox, Chrome, and iOS + macOS Safari.  Please let me know if you require any more information to get this merged :)