### PR TITLE
Do not use static paths for icons

### DIFF
--- a/components/IconCard.tsx
+++ b/components/IconCard.tsx
@@ -21,7 +21,11 @@ export const IconCard = ({ title, icon, copy, className }: IconCardProps) => {
     >
       <div className="flex h-44 w-full items-center justify-center text-blurple-500">
         <div className="relative h-[7.5rem] w-[7.5rem]">
-          <Image src={`/icons/${icon}.svg`} layout="fill" alt="" />
+          <Image
+            src={require(`../public/icons/${icon}.svg`)}
+            layout="fill"
+            alt=""
+          />
         </div>
       </div>
       <div className="flex flex-col gap-2 p-8 pt-0">

--- a/next.config.js
+++ b/next.config.js
@@ -36,10 +36,13 @@ const nextConfig = {
     ]
   },
   webpack(config, { isServer, isdev }) {
-    // custom rule for SVGr
+    // custom rule for SVGR
+
+    // warning: do not specify `issuer` key here, it is broken with dynamic require
+    // see https://github.com/webpack/webpack/issues/9309
+    //     https://github.com/vercel/next.js/discussions/15437
     config.module.rules.push({
       test: /\.svg$/i,
-      issuer: /\.[jt]sx?$/,
       resourceQuery: /inline/, // Only for *.svg?inline
       use: ["@svgr/webpack"],
     })
@@ -47,7 +50,6 @@ const nextConfig = {
     // we need to add this, as the previous rule disabled the default SVG loader
     config.module.rules.push({
       test: /\.svg$/i,
-      issuer: /\.[jt]sx?$/,
       resourceQuery: { not: [/inline/] },
       loader: "next-image-loader",
       options: { assetPrefix: "", basePath: "", isServer, isDev: isdev },

--- a/pages/guide.tsx
+++ b/pages/guide.tsx
@@ -140,7 +140,7 @@ function Guide(props) {
                 className="relative flex flex-col items-baseline gap-4"
               >
                 <Image
-                  src={`/icons/${name}.svg`}
+                  src={require(`../public/icons/${name}.svg`)}
                   className="aspect-square"
                   width="120"
                   height="120"


### PR DESCRIPTION
This allow those icon files to be properly managed by Next.js, so we get unique file names and proper caching.

With this the whole `/servers` page and all its assets can be served from cache.