### PR TITLE
Use a helper to set some defaults for `getStaticProps`, and ensure static pages are only cached for 300s

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head"
 import BasicPage from "../components/BasicPage"
 import Hero from "../components/Hero"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import LinkButton from "../components/LinkButton"
 import { FormattedMessage, useIntl } from "react-intl"
 import Layout from "../components/Layout"
@@ -39,9 +39,6 @@ const NotFoundPage = () => (
   </Layout>
 )
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
+
 export default NotFoundPage

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,8 +1,7 @@
 import BasicPage from "../components/BasicPage"
 import Head from "next/head"
 import Hero from "../components/Hero"
-import loadIntlMessages from "../utils/loadIntlMessages"
-import classNames from "classnames"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import Layout from "../components/Layout"
 import heroImage from "../public/illustrations/apps_hero_desktop.png"
 import Image from "next/image"
@@ -64,15 +63,25 @@ const About = () => (
               </p>
 
               <ul className="b1 space-y-4">
-                <li><LinkWithArrow href="/branding">Branding</LinkWithArrow></li>
-                <li><LinkWithArrow href="/trademark">Trademark Policy</LinkWithArrow></li>
+                <li>
+                  <LinkWithArrow href="/branding">Branding</LinkWithArrow>
+                </li>
+                <li>
+                  <LinkWithArrow href="/trademark">
+                    Trademark Policy
+                  </LinkWithArrow>
+                </li>
               </ul>
             </div>
 
             <div className="col-span-12 md:col-span-6">
-              <h2 className="h3 mb-6" id="team">Meet the team</h2>
+              <h2 className="h3 mb-6" id="team">
+                Meet the team
+              </h2>
 
-              <p className="mb-6 b1"><LinkWithArrow href="/careers">Join the team</LinkWithArrow></p>
+              <p className="b1 mb-6">
+                <LinkWithArrow href="/careers">Join the team</LinkWithArrow>
+              </p>
 
               <div className="grid grid-cols-12 gap-gutter">
                 {team.map((member) => (
@@ -392,10 +401,6 @@ const Metrics = () => {
   )
 }
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default About

--- a/pages/android/privacy.tsx
+++ b/pages/android/privacy.tsx
@@ -1,7 +1,7 @@
 import BasicPage from "../../components/BasicPage"
 import Head from "next/head"
 import Hero from "../../components/Hero"
-import loadIntlMessages from "../../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../../utils/defaultStaticProps"
 import Layout from "../../components/Layout"
 
 /** This page does not require translations */
@@ -36,9 +36,5 @@ const Privacy = () => (
     </div>
   </Layout>
 )
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 export default Privacy

--- a/pages/apps.tsx
+++ b/pages/apps.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage, useIntl } from "react-intl"
 import Head from "next/head"
 import Image from "next/image"
 import AppHero from "../components/AppHero"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import footer_festival from "../public/illustrations/footer_festival.png"
 import AppsGrid from "../components/AppsGrid"
 import TwoUpFeature from "../components/TwoUpFeature"
@@ -171,10 +171,6 @@ const AppsPage = () => {
   )
 }
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default AppsPage

--- a/pages/branding.tsx
+++ b/pages/branding.tsx
@@ -1,7 +1,7 @@
 import BasicPage from "../components/BasicPage"
 import Head from "next/head"
 import Hero from "../components/Hero"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import classNames from "classnames"
 import Layout from "../components/Layout"
 import heroImage from "../public/illustrations/apps_hero_desktop.png"
@@ -200,7 +200,7 @@ const Branding = () => (
             </p>
           }
           preview={
-            <div className="flex flex-col items-center justify-center gap-4 sm:flex-row md:gap-32 overflow-hidden">
+            <div className="flex flex-col items-center justify-center gap-4 overflow-hidden sm:flex-row md:gap-32">
               {[LogoPurple, WordmarkWhiteText].map((Svg, i) => (
                 <div
                   className="relative rounded bg-eggplant p-[36px] text-blurple-600 shadow-[currentColor_0_0_0_1px_inset]"
@@ -327,9 +327,5 @@ const Branding = () => (
     </div>
   </Layout>
 )
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 export default Branding

--- a/pages/careers.tsx
+++ b/pages/careers.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import Head from "next/head"
 import Hero from "../components/Hero"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import Layout from "../components/Layout"
 import LinkButton from "../components/LinkButton"
 import Link from "next/link"
@@ -16,23 +16,32 @@ import press from "../data/press"
 
 /** This page does not require translations */
 const Careers = () => {
-  const jobsResponse = useQuery<JobsResponse>(["jobs"], () => fetchEndpoint("jobs", {}), {
-    cacheTime: 10 * 60 * 1000, // 10 minutes
+  const jobsResponse = useQuery<JobsResponse>(
+    ["jobs"],
+    () => fetchEndpoint("jobs", {}),
+    {
+      cacheTime: 10 * 60 * 1000, // 10 minutes
 
-    select: data => {
-      return _groupBy(data.results, "departmentName")
-    },
-  })
+      select: (data) => {
+        return _groupBy(data.results, "departmentName")
+      },
+    }
+  )
 
   return (
     <Layout>
       <div dir="ltr" className="[unicode-bidi:plaintext]">
         <Hero homepage>
-          <div className="pt-6 b2 !font-bold uppercase text-nightshade-100">Careers</div>
+          <div className="b2 pt-6 !font-bold uppercase text-nightshade-100">
+            Careers
+          </div>
 
           <h1 className="h1 mb-4">Join our team</h1>
 
-          <p className="sh1 mb-11 max-w-[50ch]">We&apos;re building open source, decentralized social media that gives people back control over their data and their reach.</p>
+          <p className="sh1 mb-11 max-w-[50ch]">
+            We&apos;re building open source, decentralized social media that
+            gives people back control over their data and their reach.
+          </p>
 
           <div className="flex justify-center">
             <LinkButton size="large" href="#open-positions">
@@ -46,24 +55,41 @@ const Careers = () => {
             <div className="grid grid-cols-12 gap-y-24 py-20 md:gap-x-12">
               <div className="col-span-12 md:col-span-4">
                 <h2 className="h3 mb-4">Work with us</h2>
-                <p className="b1 mb-4">Mastodon is German non-profit with a remote-only, primarily English-speaking team distributed across the world.</p>
-                <p className="mb-6 b1"><LinkWithArrow href="/about#team">Meet the team</LinkWithArrow></p>
+                <p className="b1 mb-4">
+                  Mastodon is German non-profit with a remote-only, primarily
+                  English-speaking team distributed across the world.
+                </p>
+                <p className="b1 mb-6">
+                  <LinkWithArrow href="/about#team">
+                    Meet the team
+                  </LinkWithArrow>
+                </p>
 
-                <ul className="list-disc b1 space-y-2">
-                  <li>Be part of a small team working on the generational opportunity of the future of social media.</li>
-                  <li>We can offer work contracts through a payroll provider such as Remote.com or directly if you&apos;re based in Germany.</li>
+                <ul className="b1 list-disc space-y-2">
+                  <li>
+                    Be part of a small team working on the generational
+                    opportunity of the future of social media.
+                  </li>
+                  <li>
+                    We can offer work contracts through a payroll provider such
+                    as Remote.com or directly if you&apos;re based in Germany.
+                  </li>
                 </ul>
               </div>
 
               <div className="col-span-12 md:col-span-8">
-                <h2 id="open-positions" className="h3 mb-6">Open positions</h2>
+                <h2 id="open-positions" className="h3 mb-6">
+                  Open positions
+                </h2>
 
                 <JobBoard jobs={jobsResponse} />
               </div>
 
               <div className="col-span-12">
                 <h2 className="h3 mb-4">In the news</h2>
-                <p className="mb-8 b1"><LinkWithArrow href="/about#press">Read more</LinkWithArrow></p>
+                <p className="b1 mb-8">
+                  <LinkWithArrow href="/about#press">Read more</LinkWithArrow>
+                </p>
 
                 <div className="grid grid-cols-12 gap-gutter">
                   {press
@@ -80,18 +106,9 @@ const Careers = () => {
 
         <Head>
           <title>Careers - Mastodon</title>
-          <meta
-            property="og:title"
-            content="Careers at Mastodon"
-          />
-          <meta
-            property="og:description"
-            content="Join our team."
-          />
-          <meta
-            property="description"
-            content="Join our team."
-          />
+          <meta property="og:title" content="Careers at Mastodon" />
+          <meta property="og:description" content="Join our team." />
+          <meta property="description" content="Join our team." />
         </Head>
       </div>
     </Layout>
@@ -99,18 +116,22 @@ const Careers = () => {
 }
 
 const Job = ({ job }: { job?: Job }) => (
-  <li className="border-b last:border-0 border-gray-4 flex py-4">
-    <div className="flex-1 b1 !font-bold">
+  <li className="flex border-b border-gray-4 py-4 last:border-0">
+    <div className="b1 flex-1 !font-bold">
       {job ? job.title : <SkeletonText className="w-[14ch]" />}
     </div>
 
-    <div className="flex-shrink-0 b2">
-      {job ? <Link href={job.externalLink}>
-        <a className="font-semibold text-blurple-600 hocus:underline flex items-center gap-2">
-          {job.locationName}
-          <Arrow className="h-[1em]" />
-        </a>
-      </Link> : <SkeletonText className="w-[7ch]" />}
+    <div className="b2 flex-shrink-0">
+      {job ? (
+        <Link href={job.externalLink}>
+          <a className="flex items-center gap-2 font-semibold text-blurple-600 hocus:underline">
+            {job.locationName}
+            <Arrow className="h-[1em]" />
+          </a>
+        </Link>
+      ) : (
+        <SkeletonText className="w-[7ch]" />
+      )}
     </div>
   </li>
 )
@@ -119,32 +140,35 @@ const JobBoard = ({ jobs }) => {
   if (jobs.data?.length === 0) {
     return (
       <div className="b2 flex justify-center rounded bg-gray-5 p-4 text-gray-1 md:p-8 md:py-20">
-        <p className="max-w-[48ch] text-center">No positions available right now.</p>
+        <p className="max-w-[48ch] text-center">
+          No positions available right now.
+        </p>
       </div>
     )
   }
 
   return (
     <div>
-      {jobs.isLoading ? Array(4).fill(null).map((_, i) => (
-        <Job key={i} />)
-      ) : Object.keys(jobs.data).map(departmentName => (
-        <div key={departmentName} className="pb-6 mb-6 border-b border-gray-4 last:border-0">
-          <h3 className="b2 text-nightshade-300">{departmentName}</h3>
+      {jobs.isLoading
+        ? Array(4)
+            .fill(null)
+            .map((_, i) => <Job key={i} />)
+        : Object.keys(jobs.data).map((departmentName) => (
+            <div
+              key={departmentName}
+              className="mb-6 border-b border-gray-4 pb-6 last:border-0"
+            >
+              <h3 className="b2 text-nightshade-300">{departmentName}</h3>
 
-          {jobs.data[departmentName].map(job => (
-            <Job key={job.id} job={job} />
+              {jobs.data[departmentName].map((job) => (
+                <Job key={job.id} job={job} />
+              ))}
+            </div>
           ))}
-        </div>
-      ))}
     </div>
   )
 }
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default Careers

--- a/pages/guide.tsx
+++ b/pages/guide.tsx
@@ -1,6 +1,6 @@
 import app_hero_planets from "../public/illustrations/app_hero_planets.png"
 import app_hero_festival from "../public/illustrations/app_hero_festival.png"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import { IconCard } from "../components/IconCard"
 import SelectMenu from "../components/SelectMenu"
 import { FormattedMessage, useIntl } from "react-intl"
@@ -374,8 +374,4 @@ function Guide(props) {
 
 export default Guide
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import "keen-slider/keen-slider.min.css"
 import resolveConfig from "tailwindcss/resolveConfig"
 import twConfig from "../tailwind.config"
 
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import LinkButton from "../components/LinkButton"
 import TestimonialCard from "../components/TestimonialCard"
 import SponsorLogoGroup from "../components/SponsorLogoGroup"
@@ -525,8 +525,4 @@ const Sponsors = ({ sponsors }) => {
   )
 }
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()

--- a/pages/ios/privacy.tsx
+++ b/pages/ios/privacy.tsx
@@ -1,7 +1,7 @@
 import BasicPage from "../../components/BasicPage"
 import Head from "next/head"
 import Hero from "../../components/Hero"
-import loadIntlMessages from "../../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../../utils/defaultStaticProps"
 import Layout from "../../components/Layout"
 
 /** This page does not require translations */
@@ -36,9 +36,5 @@ const Privacy = () => (
     </div>
   </Layout>
 )
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 export default Privacy

--- a/pages/privacy-policy.tsx
+++ b/pages/privacy-policy.tsx
@@ -1,7 +1,7 @@
 import BasicPage from "../components/BasicPage"
 import Head from "next/head"
 import Hero from "../components/Hero"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import Layout from "../components/Layout"
 
 /** This page does not require translations */
@@ -59,9 +59,5 @@ const PrivacyPolicy = () => (
     </div>
   </Layout>
 )
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 export default PrivacyPolicy

--- a/pages/roadmap.tsx
+++ b/pages/roadmap.tsx
@@ -1,7 +1,7 @@
 import BasicPage from "../components/BasicPage"
 import Head from "next/head"
 import Hero from "../components/Hero"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import Layout from "../components/Layout"
 import data from "../data/roadmap"
 import IssueTimeline from "../components/IssueTimeline"
@@ -17,11 +17,21 @@ const Roadmap = () => {
         <Hero homepage safeTextShadow={false} noHeight>
           <div className="grid gap-x-gutter gap-y-16 lg:grid-cols-12">
             <div className="full-width-bg__inner lg:col-span-5 lg:text-end">
-              <h1 className="h1 mb-8 pt-16"><FormattedMessage id="roadmap.title" defaultMessage="Roadmap" /></h1>
-              <p className="sh1 mb-11"><FormattedMessage id="roadmap.lead" defaultMessage="This is a glimpse into what we're working on and what we're planning to work on." /></p>
+              <h1 className="h1 mb-8 pt-16">
+                <FormattedMessage id="roadmap.title" defaultMessage="Roadmap" />
+              </h1>
+              <p className="sh1 mb-11">
+                <FormattedMessage
+                  id="roadmap.lead"
+                  defaultMessage="This is a glimpse into what we're working on and what we're planning to work on."
+                />
+              </p>
 
               <div className="flex justify-center lg:justify-end">
-                <LinkButton size="large" href="https://github.com/mastodon/mastodon/issues">
+                <LinkButton
+                  size="large"
+                  href="https://github.com/mastodon/mastodon/issues"
+                >
                   <FormattedMessage
                     id="roadmap.suggest_a_feature"
                     defaultMessage="Suggest a feature"
@@ -30,7 +40,7 @@ const Roadmap = () => {
               </div>
             </div>
 
-            <div className="lg:col-span-7 text-start max-w-[100vw]">
+            <div className="max-w-[100vw] text-start lg:col-span-7">
               <IssueTimeline roadmap={data} />
             </div>
           </div>
@@ -45,19 +55,33 @@ const Roadmap = () => {
             - Mastodon
           </title>
 
-          <meta property="og:title" content={intl.formatMessage({ id: "roadmap.page_title", defaultMessage: "Public Roadmap" })} />
-          <meta name="description" content={intl.formatMessage({ id: "roadmap.page_description", defaultMessage: "Learn what we are working on in Mastodon" })} />
-          <meta name="og:description" content={intl.formatMessage({ id: "roadmap.page_description", defaultMessage: "Learn what we are working on in Mastodon" })} />
+          <meta
+            property="og:title"
+            content={intl.formatMessage({
+              id: "roadmap.page_title",
+              defaultMessage: "Public Roadmap",
+            })}
+          />
+          <meta
+            name="description"
+            content={intl.formatMessage({
+              id: "roadmap.page_description",
+              defaultMessage: "Learn what we are working on in Mastodon",
+            })}
+          />
+          <meta
+            name="og:description"
+            content={intl.formatMessage({
+              id: "roadmap.page_description",
+              defaultMessage: "Learn what we are working on in Mastodon",
+            })}
+          />
         </Head>
       </div>
     </Layout>
   )
 }
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default Roadmap

--- a/pages/servers.tsx
+++ b/pages/servers.tsx
@@ -11,7 +11,7 @@ import Statistic from "../components/Statistic"
 import { categoriesMessages } from "../data/categories"
 import type { Server, Category, Language, Day, Region } from "../types/api"
 import Hero from "../components/Hero"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import { formatNumber } from "../utils/numbers"
 import { fetchEndpoint } from "../utils/api"
 
@@ -700,10 +700,6 @@ const ServerFilters = ({
   )
 }
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 
 export default Servers

--- a/pages/sponsors.tsx
+++ b/pages/sponsors.tsx
@@ -4,7 +4,7 @@ import Hero from "../components/Hero"
 import SponsorCard from "../components/SponsorCard"
 import SponsorLogoGroup from "../components/SponsorLogoGroup"
 import TwoUpFeature from "../components/TwoUpFeature"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import sponsors from "../data/sponsors"
 import sponsorData from "../data/sponsors"
 import Layout from "../components/Layout"
@@ -183,8 +183,4 @@ function Sponsors() {
 
 export default Sponsors
 
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()

--- a/pages/trademark.tsx
+++ b/pages/trademark.tsx
@@ -1,7 +1,7 @@
 import BasicPage from "../components/BasicPage"
 import Head from "next/head"
 import Hero from "../components/Hero"
-import loadIntlMessages from "../utils/loadIntlMessages"
+import { withDefaultStaticProps } from "../utils/defaultStaticProps"
 import Layout from "../components/Layout"
 
 /** This page does not require translations */
@@ -14,60 +14,153 @@ const Trademark = () => (
       </Hero>
 
       <BasicPage>
-        <p className="b1 mb-4">The Mastodon name and logos are trademarks of Mastodon gGmbH. As such, their use is restricted and protected by intellectual property law. While the software we create is available under a free and open source software license, the copyright license does not include an implied right or license to use our trademarks.</p>
-        <p className="b1 mb-4">The role of trademarks is to prevent the exploitation of the good name and reputation of Mastodon by other people and organizations, and to provide assurance about the quality of the products and services associated with it.</p>
-        <p className="b1 mb-4">To use our trademarks beyond what is considered &quot;fair&quot; or &quot;nominative&quot; use, you must follow these guidelines.  By making use of our trademarks, you agree to abide by the following terms and conditions.  You further agree that any dispute arising in connection with your use of our trademarks or under these terms and conditions shall be under the exclusive jurisdiction of the state and federal courts of New York in the United States of America and that the state and federal courts of New York shall have personal jurisdiction over you for the purposes of adjudicating any dispute concerning the use of our trademarks or these terms and conditions.</p>
-        <p className="b1 mb-4">You agree to defend and indemnify Mastodon gGmbH from and against any and all claims and losses brought by a third party in connection with your use of the Mastodon trademarks.</p>
-        <p className="b1 mb-4">To request the use of the Mastodon name and logos in a way not covered in these guidelines, or to report violations, please contact us at <a href="mailto:trademark@joinmastodon.org" className="text-blurple-500 hover:underline">trademark@joinmastodon.org</a>.  In the event that we do not approve such use of the Mastodon name and logos within ten (10) business days, your request shall be deemed denied.</p>
+        <p className="b1 mb-4">
+          The Mastodon name and logos are trademarks of Mastodon gGmbH. As such,
+          their use is restricted and protected by intellectual property law.
+          While the software we create is available under a free and open source
+          software license, the copyright license does not include an implied
+          right or license to use our trademarks.
+        </p>
+        <p className="b1 mb-4">
+          The role of trademarks is to prevent the exploitation of the good name
+          and reputation of Mastodon by other people and organizations, and to
+          provide assurance about the quality of the products and services
+          associated with it.
+        </p>
+        <p className="b1 mb-4">
+          To use our trademarks beyond what is considered &quot;fair&quot; or
+          &quot;nominative&quot; use, you must follow these guidelines. By
+          making use of our trademarks, you agree to abide by the following
+          terms and conditions. You further agree that any dispute arising in
+          connection with your use of our trademarks or under these terms and
+          conditions shall be under the exclusive jurisdiction of the state and
+          federal courts of New York in the United States of America and that
+          the state and federal courts of New York shall have personal
+          jurisdiction over you for the purposes of adjudicating any dispute
+          concerning the use of our trademarks or these terms and conditions.
+        </p>
+        <p className="b1 mb-4">
+          You agree to defend and indemnify Mastodon gGmbH from and against any
+          and all claims and losses brought by a third party in connection with
+          your use of the Mastodon trademarks.
+        </p>
+        <p className="b1 mb-4">
+          To request the use of the Mastodon name and logos in a way not covered
+          in these guidelines, or to report violations, please contact us at 
+          <a
+            href="mailto:trademark@joinmastodon.org"
+            className="text-blurple-500 hover:underline"
+          >
+            trademark@joinmastodon.org
+          </a>
+          . In the event that we do not approve such use of the Mastodon name
+          and logos within ten (10) business days, your request shall be deemed
+          denied.
+        </p>
 
         <h2 className="h5 mt-12 mb-6">General guidelines</h2>
         <p className="b1 mb-4">In general:</p>
 
-        <ul className="space-y-4 list-disc pl-5 b1">
-          <li>Only use the Mastodon marks to accurately identify those goods or services that are built using the Mastodon software.</li>
-          <li>Do not use the Mastodon marks in any way that could mistakenly imply that Mastodon GmbH has reviewed, approved, or guaranteed your goods or services.</li>
-          <li>Do not use or register, in whole or in part, the Mastodon marks as part of your own or any other trademark, service mark, domain name, company name, trade name, product name, or service name.</li>
-          <li>Do not use the Mastodon marks in a manner that disparages or defames the marks, Mastodon gGmbH, or Mastodon’s products.</li>
-          <li>Do not use the Mastodon marks in connection with any illegal activity.</li>
-          <li>You may use the Mastodon word mark in referential phrases such as &quot;for&quot;, &quot;for use with&quot;, or &quot;compatible with&quot;.</li>
-          <li>You may use the Mastodon marks when embedding or otherwise displaying user generated content published using the Mastodon software.</li>
+        <ul className="b1 list-disc space-y-4 pl-5">
+          <li>
+            Only use the Mastodon marks to accurately identify those goods or
+            services that are built using the Mastodon software.
+          </li>
+          <li>
+            Do not use the Mastodon marks in any way that could mistakenly imply
+            that Mastodon GmbH has reviewed, approved, or guaranteed your goods
+            or services.
+          </li>
+          <li>
+            Do not use or register, in whole or in part, the Mastodon marks as
+            part of your own or any other trademark, service mark, domain name,
+            company name, trade name, product name, or service name.
+          </li>
+          <li>
+            Do not use the Mastodon marks in a manner that disparages or defames
+            the marks, Mastodon gGmbH, or Mastodon’s products.
+          </li>
+          <li>
+            Do not use the Mastodon marks in connection with any illegal
+            activity.
+          </li>
+          <li>
+            You may use the Mastodon word mark in referential phrases such as
+            &quot;for&quot;, &quot;for use with&quot;, or &quot;compatible
+            with&quot;.
+          </li>
+          <li>
+            You may use the Mastodon marks when embedding or otherwise
+            displaying user generated content published using the Mastodon
+            software.
+          </li>
           <li>Do not change or modify the Mastodon marks.</li>
-          <li>Any all use of the Mastodon marks, and any goodwill accrued as a result of that use, belongs entirely to, and shall inure for the benefit of, Mastodon gGmbH.</li>
+          <li>
+            Any all use of the Mastodon marks, and any goodwill accrued as a
+            result of that use, belongs entirely to, and shall inure for the
+            benefit of, Mastodon gGmbH.
+          </li>
         </ul>
 
         <h2 className="h5 mt-12 mb-6">Server guidelines</h2>
-        <p className="b1 mb-4">If you run your own Mastodon server using the Mastodon software, including modified Mastodon software on the condition that the modifications are limited to switching on or off features already included in the software, minor tweaks in visual appearance, translations into other languages, and bug fixes:</p>
+        <p className="b1 mb-4">
+          If you run your own Mastodon server using the Mastodon software,
+          including modified Mastodon software on the condition that the
+          modifications are limited to switching on or off features already
+          included in the software, minor tweaks in visual appearance,
+          translations into other languages, and bug fixes:
+        </p>
 
-        <ul className="space-y-4 list-disc pl-5 b1">
-          <li>You may not use the Mastodon word mark, or any similar mark, in your domain name, unless you have written permission from Mastodon gGmbH.</li>
-          <li>As long as you abide by the terms and conditions of this agreement, you may use the Mastodon marks included in the Mastodon server software for the purposes of running the server.</li>
+        <ul className="b1 list-disc space-y-4 pl-5">
+          <li>
+            You may not use the Mastodon word mark, or any similar mark, in your
+            domain name, unless you have written permission from Mastodon gGmbH.
+          </li>
+          <li>
+            As long as you abide by the terms and conditions of this agreement,
+            you may use the Mastodon marks included in the Mastodon server
+            software for the purposes of running the server.
+          </li>
         </ul>
 
         <h2 className="h5 mt-12 mb-6">Open source project guidelines</h2>
-        <p className="b1 mb-4">If you choose to build on or modify Mastodon&apos;s open-source code, beyond modifications limited to switching on or off features already included in the software, minor tweaks in visual appearance, translations into other languages, and bug fixes:</p>
+        <p className="b1 mb-4">
+          If you choose to build on or modify Mastodon&apos;s open-source code,
+          beyond modifications limited to switching on or off features already
+          included in the software, minor tweaks in visual appearance,
+          translations into other languages, and bug fixes:
+        </p>
 
-        <ul className="space-y-4 list-disc pl-5 b1">
-          <li>You must choose your own branding, logos, and trademarks that denote your unique identity so as to clearly signal to users that there is no affiliation with or endorsement by Mastodon gGmbH.</li>
-          <li>You may use word marks, but not our logos, in truthful statements that describe the relationship between your software and ours, for example &quot;this software is derived from the source code of the Mastodon software&quot;.</li>
+        <ul className="b1 list-disc space-y-4 pl-5">
+          <li>
+            You must choose your own branding, logos, and trademarks that denote
+            your unique identity so as to clearly signal to users that there is
+            no affiliation with or endorsement by Mastodon gGmbH.
+          </li>
+          <li>
+            You may use word marks, but not our logos, in truthful statements
+            that describe the relationship between your software and ours, for
+            example &quot;this software is derived from the source code of the
+            Mastodon software&quot;.
+          </li>
         </ul>
 
         <h2 className="h5 mt-12 mb-6">Social media guidelines</h2>
-        <p className="b1 mb-4">The name and handle of your social media account and any and all pages cannot begin with a Mastodon word mark, or a similar mark (e.g. &quot;mastodoon&quot;, &quot;mast0don&quot;, &quot;mstdn&quot;). In addition, Mastodon logos cannot be used in a way that might suggest affiliation with or endorsement by Mastodon.</p>
+        <p className="b1 mb-4">
+          The name and handle of your social media account and any and all pages
+          cannot begin with a Mastodon word mark, or a similar mark (e.g.
+          &quot;mastodoon&quot;, &quot;mast0don&quot;, &quot;mstdn&quot;). In
+          addition, Mastodon logos cannot be used in a way that might suggest
+          affiliation with or endorsement by Mastodon.
+        </p>
       </BasicPage>
 
       <Head>
         <title>Trademark Policy - Mastodon</title>
-        <meta
-          property="og:title"
-          content="Trademark Policy of Mastodon"
-        />
+        <meta property="og:title" content="Trademark Policy of Mastodon" />
       </Head>
     </div>
   </Layout>
 )
-export async function getStaticProps(ctx) {
-  return {
-    props: { intlMessages: await loadIntlMessages(ctx) },
-  }
-}
+export const getStaticProps = withDefaultStaticProps()
 export default Trademark

--- a/utils/defaultStaticProps.ts
+++ b/utils/defaultStaticProps.ts
@@ -1,0 +1,17 @@
+import loadIntlMessages from "./loadIntlMessages"
+
+export function withDefaultStaticProps(origin?) {
+  return async (ctx) => {
+    const {
+      props: originProps = {},
+      revalidate = undefined,
+      ...originRemaining
+    } = origin ? await origin(ctx) : {}
+
+    return {
+      props: { intlMessages: await loadIntlMessages(ctx), ...originProps },
+      revalidate: revalidate || 300,
+      ...originRemaining,
+    }
+  }
+}


### PR DESCRIPTION
Without `revalidate`, then Next.js have them cached for 1 year by the CDN.