### PR TITLE
Cache the font files

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,19 @@ const nextConfig = {
       "c10.patreonusercontent.com",
     ],
   },
+  async headers() {
+    return [
+      {
+        source: "/fonts/:all*(ttf|otf|woff|woff2)",
+        headers: [
+          {
+            key: "Cache-control",
+            value: "max-age=3600, stale-while-revalidate",
+          },
+        ],
+      },
+    ]
+  },
   async redirects() {
     return [
       {


### PR DESCRIPTION
Currently they are not cached, either locally or by the CDN.

With Next.js 13, `@next/font` should allow to handle this better.