### PR TITLE
Improve caching for favicons / preview image

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -5,6 +5,8 @@ import Header from "./Header"
 import { locales, defaultLocale } from "../data/locales"
 import { useRouter } from "next/router"
 
+import previewImage from "../public/preview.png"
+
 const BASE_URL = "https://joinmastodon.org"
 
 /** Default layout component */
@@ -34,10 +36,7 @@ export const Layout = ({
       <Footer />
 
       <Head>
-        <meta
-          property="og:image"
-          content="https://joinmastodon.org/preview.png"
-        />
+        <meta property="og:image" content={`${BASE_URL}${previewImage.src}`} />
         <meta property="twitter:card" content="summary_large_image" />
 
         {locales

--- a/next.config.js
+++ b/next.config.js
@@ -15,17 +15,21 @@ const nextConfig = {
     ],
   },
   async headers() {
+    // These static files are references with hardcoded URLs and need proper Cache-Control headers
     return [
-      {
-        source: "/fonts/:all*(ttf|otf|woff|woff2)",
-        headers: [
-          {
-            key: "Cache-control",
-            value: "max-age=3600, stale-while-revalidate",
-          },
-        ],
-      },
-    ]
+      "/fonts/:all*(ttf|otf|woff|woff2)",
+      "/favicon-:all*(png)",
+      "/app-icon.png",
+      "/preview.png",
+    ].map((source) => ({
+      source,
+      headers: [
+        {
+          key: "Cache-control",
+          value: "max-age=3600, stale-while-revalidate",
+        },
+      ],
+    }))
   },
   async redirects() {
     return [

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router"
+import Head from "next/head"
 import { IntlProvider } from "react-intl"
 import { useEffect } from "react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
@@ -6,6 +7,9 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 import { getDirForLocale } from "../utils/locales"
 import "../styles/globals.scss"
+
+import favicon32 from "../public/favicon-32x32.png"
+import favicon16 from "../public/favicon-16x16.png"
 
 function MyApp({ Component, pageProps }) {
   const { locale, defaultLocale } = useRouter()
@@ -23,6 +27,20 @@ function MyApp({ Component, pageProps }) {
       messages={pageProps.intlMessages}
     >
       <QueryClientProvider client={queryClient}>
+        <Head>
+          <link
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href={favicon32.src}
+          />
+          <link
+            rel="icon"
+            type="image/png"
+            sizes="16x16"
+            href={favicon16.src}
+          />
+        </Head>
         <Component {...pageProps} />
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -12,18 +12,6 @@ class MyDocument extends Document {
     return (
       <Html dir={dir}>
         <Head>
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="32x32"
-            href="/favicon-32x32.png"
-          />
-          <link
-            rel="icon"
-            type="image/png"
-            sizes="16x16"
-            href="/favicon-16x16.png"
-          />
           <meta name="apple-itunes-app" content="app-id=1571998974" />
           <meta name="twitter:site" content="@joinmastodon" />
         </Head>


### PR DESCRIPTION
Currently those files are not cached by the CDN, resulting is useless trafic to the origin.

This PR ensures those files have proper Cache-Control headers.

- When possible, import the path in JS so Next.js can generate a content-dependant URLs with infinite caching
- Set a 1h cache for those assets if the static path is used

Images cant be imported from `_document.js`, so I moved them to `_app.tsx`