### PR TITLE
Reorder sign-up process options

### DIFF
--- a/pages/servers.tsx
+++ b/pages/servers.tsx
@@ -101,7 +101,7 @@ const Servers = () => {
       }),
     },
     {
-      value: "",
+      value: "all",
       label: intl.formatMessage({
         id: "wizard.filter.sign_up.all",
         defaultMessage: "All",
@@ -269,7 +269,7 @@ const Servers = () => {
               onChange={(v) => {
                 setFilters({ ...filters, registrations: v })
               }}
-              value={filters.registrations}
+              value={filters.registrations || "instant" }
               options={registrationsOptions}
             />
 

--- a/pages/servers.tsx
+++ b/pages/servers.tsx
@@ -87,13 +87,6 @@ const Servers = () => {
 
   const registrationsOptions = [
     {
-      value: "",
-      label: intl.formatMessage({
-        id: "wizard.filter.sign_up.all",
-        defaultMessage: "All",
-      }),
-    },
-    {
       value: "instant",
       label: intl.formatMessage({
         id: "wizard.filter.sign_up.instant",
@@ -105,6 +98,13 @@ const Servers = () => {
       label: intl.formatMessage({
         id: "wizard.filter.sign_up.manual",
         defaultMessage: "Manual review",
+      }),
+    },
+    {
+      value: "",
+      label: intl.formatMessage({
+        id: "wizard.filter.sign_up.all",
+        defaultMessage: "All",
       }),
     },
   ]


### PR DESCRIPTION
This covers the third point of https://mastodon.social/@atomicpoet/109821361045588259

The original order is:
* all
* instant
* manual

I'm proposing to change it to:
* instant
* manual
* all

We expect that most users will want instant. Some will want manual. But, oddly, most users are least likely to want all.