### PR TITLE
Fix #333 Bug: app multiplying on the Apps page

### DIFF
--- a/components/AppCard.tsx
+++ b/components/AppCard.tsx
@@ -15,7 +15,7 @@ export type AppCardProps = {
 export const AppCard = ({ name, icon, url, paid }) => {
   return (
     <a
-      key={url + name}
+      key={`${url} ${name}`}
       href={url}
       target="_blank"
       rel="noopener noreferrer"

--- a/components/AppCard.tsx
+++ b/components/AppCard.tsx
@@ -15,7 +15,7 @@ export type AppCardProps = {
 export const AppCard = ({ name, icon, url, paid }) => {
   return (
     <a
-      key={url}
+      key={url + name}
       href={url}
       target="_blank"
       rel="noopener noreferrer"


### PR DESCRIPTION
Possible fix for the duplicated app on the Apps page, due to duplicated `key`. Adding `name` here, assuming that it'll be unique enough 🤞