### PR TITLE
Added error handling and stronger typing

### DIFF
--- a/pages/careers.tsx
+++ b/pages/careers.tsx
@@ -18,7 +18,7 @@ import press from "../data/press"
 const Careers = () => {
   const jobsResponse = useQuery<JobsResponse>(
     ["jobs"],
-    () => fetchEndpoint("jobs", {}),
+    () => fetchEndpoint("jobs"),
     {
       cacheTime: 10 * 60 * 1000, // 10 minutes
 
@@ -137,7 +137,15 @@ const Job = ({ job }: { job?: Job }) => (
 )
 
 const JobBoard = ({ jobs }) => {
-  if (jobs.data?.length === 0) {
+  if (jobs.error) {
+    return (
+      <div className="b2 flex justify-center rounded bg-gray-5 p-4 text-gray-1 md:p-8 md:py-20">
+        <p className="max-w-[48ch] text-center">
+          Failed to retrieve positions, please try again later.
+        </p>
+      </div>
+    )
+  } else if (jobs.data?.length === 0) {
     return (
       <div className="b2 flex justify-center rounded bg-gray-5 p-4 text-gray-1 md:p-8 md:py-20">
         <p className="max-w-[48ch] text-center">

--- a/pages/servers.tsx
+++ b/pages/servers.tsx
@@ -45,7 +45,7 @@ const Servers = () => {
 
   const allCategories = useQuery<Category[]>(
     ["categories", ""],
-    () => fetchEndpoint("categories", {}),
+    () => fetchEndpoint("categories"),
     { select: (data) => _orderBy(data, "servers_count", "desc") }
   )
 
@@ -167,7 +167,7 @@ const Servers = () => {
 
   const days = useQuery<Day[]>(
     ["statistics"],
-    () => fetchEndpoint("statistics", ""),
+    () => fetchEndpoint("statistics"),
     queryOptions
   )
 

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,4 +1,4 @@
-export type ApiPaths = 'jobs' | 'categories' | 'languages'| 'servers' | 'statistics'
+export type ApiPaths = 'jobs' | 'categories' | 'languages' | 'servers' | 'statistics'
 
 export type Category = {
   category: string

--- a/types/api.ts
+++ b/types/api.ts
@@ -1,3 +1,5 @@
+export type ApiPaths = 'jobs' | 'categories' | 'languages'| 'servers' | 'statistics'
+
 export type Category = {
   category: string
   servers_count: number

--- a/utils/api.ts
+++ b/utils/api.ts
@@ -1,8 +1,12 @@
+import type { ApiPaths } from "../types/api"
+
 const apiBase = "https://api.joinmastodon.org/"
 
-const getApiUrl = (path, params = "") => `${apiBase}${path}?${params}`
+const getApiUrl = (path: ApiPaths, params?: string | URLSearchParams) => (params) ? `${apiBase}${path}?${params}` : `${apiBase}${path}`
 
-export const fetchEndpoint = async function (endpoint, params): Promise<any[]|any> {
-  const res = await fetch(getApiUrl(endpoint, params.toString()))
+export const fetchEndpoint = async (endpoint: ApiPaths, params?: string | URLSearchParams): Promise<any[]|any> => {
+  const res = await fetch(getApiUrl(endpoint, params))
+  if (!res.ok) throw new Error(res.statusText);
+  
   return await res.json()
 }


### PR DESCRIPTION
Closes #358. Implements error handling for when fetching the careers API fails. Displays the new text displayed in the screenshot below, rather than a full app crash. 

This commit also strengthens typing of API paths via the string literals: `jobs`, `categories`, `languages`, `servers`, `statistics` (more can be added, don't have the API documentation so this was more of a guess based off existing calls).

Lastly, this also fixes the params of API calls. Rather than passing in an empty object, the param is made optional and will not be appended if non-existent. ie. `https://api.joinmastodon.org/jobs?[object Object]` is now `https://api.joinmastodon.org/jobs`. 

<br>

**The new handling of a jobs API failure:**
![Screenshot from 2023-06-14 21-40-13](https://github.com/mastodon/joinmastodon/assets/83597346/81926341-d9d0-49f3-9d2b-03c56c0ed4e9)

**API calls before the param fix:**
![Screenshot from 2023-06-14 22-36-51](https://github.com/mastodon/joinmastodon/assets/83597346/a22566b8-fdaf-4c0b-8712-d530dec28be3)

**API calls after param fix, showing regular params work:**
![image](https://github.com/mastodon/joinmastodon/assets/83597346/4ac860a9-f481-4c47-8d95-c90a5b178430)

