### PR TITLE
Remove system-ui font

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -72,7 +72,7 @@ const config = {
     },
     extend: {
       fontFamily: {
-        sans: ["Manrope", ...defaultTheme.fontFamily.sans],
+        sans: ["Manrope", "-apple-system", "BlinkMacSystemFont", "\"Segoe UI\"", "Roboto", "\"Helvetica Neue\"", "Arial", "\"Noto Sans\"", "sans-serif", "\"Apple Color Emoji\"", "\"Segoe UI Emoji\"", "\"Segoe UI Symbol\"", "\"Noto Color Emoji\""],
       },
       fontWeight: {
         extranormal: 450,


### PR DESCRIPTION
The system-ui font has terrible readability in the CJK windowing environment, as shown in this article (https://infinnie.github.io/blog/2017/systemui.html).

Also, the lang attribute does not work properly in the CJK windowed environment.

![joinmastodon system-ui](https://github.com/mastodon/joinmastodon/assets/56965274/36efd19e-069a-45bc-9975-7d05f543e368)
This is a screenshot using system-ui. You can see that a Malgun Gothic(Korean font. NOT chinese font) is rendered, but this is an incorrect rendering. This is because the Chinese character shapes used in Korea are slightly different from those used in Greater China.

![joinmastodon remove system-ui2](https://github.com/mastodon/joinmastodon/assets/56965274/2397b8ec-5eca-45a4-b7a9-68caf2abd5c8)
This is a screenshot of removing system-ui. You can see that the Chinese font is rendered correctly.

The root cause of this problem is that tailwindcss set the default font-family based on the Mac environment without considering Windows (especially Windows in CJK environment). Therefore, before tailwindcss fixes this problem, we need to use the font-family with system-ui removed.
