### PR TITLE
Add `rel=me` to the team's Mastodon links

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -112,6 +112,7 @@ const About = () => (
                       {member.socials && (
                         <a
                           href={member.socials.mastodon}
+                          rel="me"
                           className="b2 ml-2 block flex-shrink-0 text-blurple-600 hover:text-blurple-500"
                         >
                           <LogoWhite


### PR DESCRIPTION
This will allow us to have a verified link to joinmastodon.org on our accounts, to confirm we are official :)