### PR TITLE
Add link to documentation from verification page

### DIFF
--- a/pages/verification.tsx
+++ b/pages/verification.tsx
@@ -175,7 +175,7 @@ const Verification = () => {
                 <p className="sh1 mb-8 text-gray-1">
                   <FormattedMessage
                     id="verification.features.how_to.body"
-                    defaultMessage={`Put a link to your Mastodon profile on your website or webpage. The important part is that the link has to have a <code>rel="me"</code> attribute on it. Then edit your Mastodon profile and put the address of your website or web page in one of your four profile fields. Save your profile, that's it!`}
+                    defaultMessage={`Put a link to your Mastodon profile on your website or webpage. The important part is that the link has to have <a href="https://docs.joinmastodon.org/user/profile/#verification">a <code>rel="me"</code> attribute</a> on it. Then edit your Mastodon profile and put the address of your website or web page in one of your four profile fields. Save your profile, that's it!`}
                     values={{
                       code: (text) => (
                         <code className="font-mono font-medium text-blurple-600">


### PR DESCRIPTION
The first search result in popular search engines for "mastodon verified" is now https://joinmastodon.org/verification, but it has no discovery path from there to more details about how this works.

Add a link to https://docs.joinmastodon.org/user/profile/#verification to address this.

Follows-up https://github.com/mastodon/joinmastodon/pull/343.