### PR TITLE
About Page: Include Mastodon, Inc 501(c)(3) mail address

### DIFF
--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -141,6 +141,18 @@ const About = () => (
                 that supports the growth and operational capabilities of Mastodon, including being able
                 to receive tax-deductible U.S. donations and in-kind support.
               </p>
+              <dl className="b1">
+                <dt className="font-bold">Address:</dt>
+                <dd>
+                    <address className="not-italic">
+                    Mastodon Inc,
+                    <br/>
+                    228 East 45th Street Suite 9E
+                    <br/>
+                    New York, New York 10017
+                  </address>
+                </dd>
+              </dl>
             </div>
 
             <div className="col-span-12 md:col-span-6">


### PR DESCRIPTION
Updated joinmastodon.org/about page to include Mastodon, Inc's mail address

<img width="1451" alt="Screenshot 2024-07-08 at 10 20 59 PM" src="https://github.com/mastodon/joinmastodon/assets/100445/553fd418-b2ea-42c2-b1a6-bca9a96f2667">
