### PR TITLE
Sponsors page: Add alt text to American flag icon

### DIFF
--- a/pages/sponsors.tsx
+++ b/pages/sponsors.tsx
@@ -180,6 +180,7 @@ function Sponsors() {
                         className="aspect-square"
                         width="20"
                         height="20"
+                        alt="Direct tax deductable donation for American residents"
                       />
                     </>
                   )}


### PR DESCRIPTION
On the sponsors page, added alt text to US flag icon in the tax deductable direct donation card.

This is a fast follow for PR https://github.com/mastodon/joinmastodon/pull/757