### PR TITLE
Update sponsors page to include links to donor policies

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -164,6 +164,7 @@
   "sponsors.donate.corporate_sponsorship.copy": "We welcome corporate sponsors! Sponsorship includes your company’s logo with a link to your website.",
   "sponsors.donate.corporate_sponsorship.cta": "Become a sponsor",
   "sponsors.donate.corporate_sponsorship.title": "Corporate Sponsorship",
+  "sponsors.donate.footer.donor_policy": "To ensure you qualify to make a donation, please refer to our donor policies: <link_mastodon_inc>Mastodon, Inc</link_mastodon_inc> <middot></middot> <link_mastodon_ggmbh>Mastodon gGmbH</link_mastodon_ggmbh>",
   "sponsors.donate.github.copy": "GitHub Sponsors receive a Mastodon badge to their Org or Personal profile. Plus we don’t pay fees!",
   "sponsors.donate.github.cta": "Donate on GitHub",
   "sponsors.donate.github.title": "GitHub",

--- a/pages/sponsors.tsx
+++ b/pages/sponsors.tsx
@@ -18,6 +18,7 @@ import MastodonsCheeringIllustration from "../public/illustrations/mastodons_che
 
 import previewImage from "../public/sponsors_preview.png"
 import usFlagIcon from "../public/united_states_flag_icon_round.svg"
+import Link from "next/link"
 
 const DonateCard = ({
   title, 
@@ -132,7 +133,6 @@ function Sponsors() {
               </p>
             </div>
 
-
             <div className="row-span-full md:col-start-6 md:col-span-6 mx-auto pt-8 md:pt-0 px-12 max-w-md md:pb-0 md:px-0">
               <Image src={MastodonsCheeringIllustration} alt="" />
             </div>
@@ -142,7 +142,7 @@ function Sponsors() {
 
       <div className="full-width-bg">
         <div className="full-width-bg__inner">
-          <div className="md:grid md:items-center md:gap-gutter md:grid-cols-12 pb-16">
+          <div className="md:grid md:items-center md:gap-gutter md:grid-cols-12 pb-1">
             <div className="md:col-span-12 md:col-start-1 xl:col-span-10 xl:col-start-2 border border-blurple-500 xl:p-16 px-12 py-12 sm:px-24 sm:py-16 md:p-12 rounded-md">
               <div className="grid max-sm:grid-cols-1 sm:grid-cols-2 gap-16 md:grid-cols-3">
                 <DonateCard
@@ -294,6 +294,25 @@ function Sponsors() {
                   )}
                   ctaLink="https://causes.benevity.org/causes/276-5575947211653_d7e4"
                   ctaLight
+                />
+              </div>
+            </div>
+          </div>
+          <div className="md:grid md:items-center md:gap-gutter md:grid-cols-12 pb-16">
+            <div className="md:col-span-12 md:col-start-1 xl:col-span-10 xl:col-start-2">
+              <div className="b4 mt-4 text-gray-2 italic pr-4 text-left md:text-right">
+                <FormattedMessage
+                  id="sponsors.donate.footer.donor_policy"
+                  defaultMessage={`To ensure you qualify to make a donation, please refer to our donor policies: <link_mastodon_inc>Mastodon, Inc</link_mastodon_inc> <middot></middot> <link_mastodon_ggmbh>Mastodon gGmbH</link_mastodon_ggmbh>`}
+                  values={{
+                    link_mastodon_inc: (text) => (
+                      <Link className="hover:text-blurple-600 ml-0.5" href="/donor-policy/mastodon-inc" target="_blank">{text}</Link>
+                    ),
+                    link_mastodon_ggmbh: (text) => (
+                      <Link className="hover:text-blurple-600" href="/donor-policy/mastodon-ggmbh" target="_blank">{text}</Link>
+                    ),
+                    middot: () => (<span className="px-0.5">&middot;</span>)
+                  }}
                 />
               </div>
             </div>


### PR DESCRIPTION
Updated sponsors page. Donate section now has a footer containing copy about Mastodon's donor policies. Links to donor policies included.

<img width="1519" alt="Screenshot 2024-09-24 at 10 48 55 PM" src="https://github.com/user-attachments/assets/270537ce-d140-42cc-b8fb-30ef6fbe754d">


