### PR TITLE
Add locale false to Link component on team page. Fixes #1025

### DIFF
--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -172,6 +172,7 @@ const About = () => (
                           <Link
                             key={`about/${member.slug}`}
                             href={`/about/${member.slug}`}
+                            locale={false}
                             className="text-blurple-600 hocus:underline"
                           >
                             {member.name}


### PR DESCRIPTION
The links for board member pages were having the locale added when a translation was applied, but only exist in English. Setting the `locale=false` here means this will not be inserted into the URL any more.